### PR TITLE
1.4. - configurable coverage quality gate, remove PMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # informaticspom
 
-The `informaticspom` is used as the parent pom for programming assignments at Fontys Venlo. 
+The `informaticspom` is used as the parent pom for programming assignments at Fontys Venlo.
 
 The goal of the `POM` is to have a baseline of dependencies that are needed for most assignments.
 
@@ -12,7 +12,7 @@ These include:
     - Mockito
 2. CodeCoverage with JaCoCo
 3. Static code analyzer
-    - PMD
+    - CheckStyle
 4. JavaFX (with the JavaFX profile)
 5. Testing modular JPMS projects
 
@@ -22,7 +22,7 @@ The pom can be used by defining it as the parent pom
 
 ```
 <parent>
-    <groupId>io.github.fontysvenlo</groupId>  
+    <groupId>io.github.fontysvenlo</groupId>
     <artifactId>informaticspom</artifactId>
     <version>0.8</version>
 </parent>
@@ -45,15 +45,14 @@ The following properties are available
 | surefire.opens | | Optional arguments that get passed to maven surefire plugin to open modules |
 | maven.surefire.version | 3.0.0-M6 | Maven surefire version |
 | maven.compiler.release | ${java.release} | The compiler release version used by maven |
-| pmdVersion | 6.42.0 | The PMD version |
 | exec.main | | The main class that should be set in the JAR by maven compiler |
 
 ## Profiles
 
-**Default**: The default dependencies (no JavaFX and doesn't generate code coverage)  
-**Jacoco**: Same as default, but generates the code coverage report  
-**JavaFX**: Includes the JavaFX dependencies  
-**Release**: Use to 
+**Default**: The default dependencies (no JavaFX and doesn't generate code coverage)
+**Jacoco**: Same as default, but generates the code coverage report
+**JavaFX**: Includes the JavaFX dependencies
+**Release**: Use to
 release new version of the `informaticspom`
 
 ## Publishing

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The following properties are available
 
 **Default**: The default dependencies (no JavaFX and doesn't generate code coverage)
 **Jacoco**: Same as default, but generates the code coverage report.
-    - `mvn verify` will fail when the `jacoco.threshold.line` and `jacoco.threshold.line` thresholds aren't met (default: 0, can be overridden via a property)
+    - `mvn verify` will fail when the `jacoco.threshold.line` and `jacoco.threshold.branch` thresholds aren't met (default: 0, can be overridden via a property)
 **JavaFX**: Includes the JavaFX dependencies
 **Release**: Use to
 release new version of the `informaticspom`

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ The following properties are available
 ## Profiles
 
 **Default**: The default dependencies (no JavaFX and doesn't generate code coverage)
-**Jacoco**: Same as default, but generates the code coverage report
+**Jacoco**: Same as default, but generates the code coverage report.
+    - `mvn verify` will fail when the `jacoco.threshold.line` and `jacoco.threshold.line` thresholds aren't met (default: 0, can be overridden via a property)
 **JavaFX**: Includes the JavaFX dependencies
 **Release**: Use to
 release new version of the `informaticspom`

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
         //  assertions.fail, uses CDATA instead of plain xml text, so for the time being stay at 2.22.2 -->
         <maven.surefire.version>3.2.5</maven.surefire.version>
         <maven.compiler.release>${java.release}</maven.compiler.release>
-        <pmd.version>6.55.0</pmd.version>
         <!-- Main class for the jar -->
         <exec.main></exec.main>
     </properties>
@@ -137,33 +136,6 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${jacoco.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.21.2</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>net.sourceforge.pmd</groupId>
-                            <artifactId>pmd-core</artifactId>
-                            <version>${pmd.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>net.sourceforge.pmd</groupId>
-                            <artifactId>pmd-java</artifactId>
-                            <version>${pmd.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>net.sourceforge.pmd</groupId>
-                            <artifactId>pmd-javascript</artifactId>
-                            <version>${pmd.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>net.sourceforge.pmd</groupId>
-                            <artifactId>pmd-jsp</artifactId>
-                            <version>${pmd.version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <description>Fontys Venlo Informatics POM</description>
     <groupId>io.github.fontysvenlo</groupId>
     <artifactId>informaticspom</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
     <packaging>pom</packaging>
     <name>FontysVenlo :: InformaticsPom</name>
     <url>https://fontysvenlo.github.io/informaticspom/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -432,6 +432,9 @@
             <properties>
                 <argLine> ${jacocoArgLine} <!---javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec-->
                 </argLine>
+                <!-- Override these in your project for a quality gate on mvn verify -->
+                <jacoco.threshold.line>0.00</jacoco.threshold.line>
+                <jacoco.threshold.branch>0.00</jacoco.threshold.branch>
             </properties>
             <dependencies>
                 <dependency>
@@ -449,43 +452,36 @@
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>default-prepare-agent</id>
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
                             </execution>
                             <execution>
-                                <id>default-prepare-agent-integration</id>
-                                <goals>
-                                    <goal>prepare-agent-integration</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>default-report</id>
+                                <id>jacoco-report</id>
+                                <phase>test</phase>
                                 <goals>
                                     <goal>report</goal>
                                 </goals>
                             </execution>
                             <execution>
-                                <id>default-report-integration</id>
+                                <id>jacoco-check</id>
                                 <goals>
-                                    <goal>report-integration</goal>
+                                    <goal>check</goal>
                                 </goals>
-                            </execution>
-                            <execution>
-                                <id>default-check</id>
                                 <configuration>
                                     <rules>
-                                        <!--  implementation is needed only for Maven 2  -->
-                                        <rule implementation="org.jacoco.maven.RuleConfiguration">
-                                            <element>BUNDLE</element>
+                                        <rule>
+                                            <element>PACKAGE</element>
                                             <limits>
-                                                <!--  implementation is needed only for Maven 2  -->
-                                                <limit
-                                                    implementation="org.jacoco.report.check.Limit">
-                                                    <counter>COMPLEXITY</counter>
+                                                <limit>
+                                                    <counter>LINE</counter>
                                                     <value>COVEREDRATIO</value>
-                                                    <minimum>0.60</minimum>
+                                                    <minimum>${jacoco.threshold.line}</minimum>
+                                                </limit>
+                                                <limit>
+                                                    <counter>BRANCH</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>${jacoco.threshold.branch}</minimum>
                                                 </limit>
                                             </limits>
                                         </rule>


### PR DESCRIPTION
## changes:
- made a configurable (via project properties, default is 0) quality gate on branch/line coverage 
    - run with `mvn verify -Pjacoco`
- removed the PMD plugin, as we didn't use them anywhere (i grepped our github and found nothing relevant)
- bumped to 1.4

## validation
I've validated this pom locally with alda_simpletime
- without setting the properties
- with setting the properties in a way they pass
- with setting the properties too high